### PR TITLE
Refactor: tidy up event handlers and simplify certain functions

### DIFF
--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -24,8 +24,39 @@ const getHeader = (name, obj) => obj.headers.get(name);
 const getRequestTypeHeader = curry(getHeader, 'Accept');
 const getResponseTypeHeader = curry(getHeader, 'Content-Type');
 
+/**
+ * openCache optionally receives one or more string arguments used to construct
+ * a key for caches.open(). If no arguments are supplied, the `VERSION` constant
+ * alone will be used as the cache key.
+ *
+ * @param {...String}
+ * @return {Promise}
+ * @example
+ *
+ *    openCache('images').then(cache => ...); // key is "0.0.0-images"
+ */
+const openCache = (...args) => {
+  const key = [VERSION].concat(args).join('-');
+  return caches.open(key);
+};
+
+/**
+ * isCacheableURL receives a URL instance and returns true or false depending on
+ * whether or not:
+ *
+ * - its pathname exists within the `cacheablePaths` array
+ * - its value matches the `cacheablePattern` regex
+ *
+ * TODO: Clean up that nasty replacement regex (for GH Pages)
+ *
+ * @param {URL}
+ * @return {Boolean}
+ * @example
+ *
+ *    isCacheableURL(new URL('example.com/nope')); // => false
+ */
 const isCacheableURL = url => {
-  const path = url.pathname.replace(/(\/)(smashing-mag-sw\/)?/, ''); // TODO: no
+  const path = url.pathname.replace(/(\/)(smashing-mag-sw\/)?/, '');
   const isPathIncluded = cacheablePaths.includes(path);
   const isURLMatching = cacheablePattern.test(url);
   return isPathIncluded || isURLMatching;

--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -1,7 +1,5 @@
 'use strict';
 
-importScripts('SMCacheUtils.js');
-
 const VERSION = '0.0.1';
 const cacheablePattern = /page[1-2]\.html$/;
 const cacheablePaths = [
@@ -63,8 +61,8 @@ const isCacheableURL = url => {
 };
 
 /**
- * getResourceTypeHeader receives a Request or Response instance, and returns a
- * header value indicating the MIME-type of that object.
+ * getResourceTypeHeader receives a Request or Response instance, and it returns
+ * a header value indicating the MIME-type of that object.
  *
  * @param {Request|Response} obj
  * @return {String}
@@ -78,19 +76,25 @@ const getResourceTypeHeader = obj => {
 };
 
 /**
- * getResourceCategory receives a Request or Response instance, and returns a
- * generic category for the MIME-type of that object. See SMCacheUtils.js for
- * the potential category values.
+ * contentType receives a Request or Response instance, and it returns a generic
+ * string alias for the MIME-type of that object.
  *
  * @param {Request|Response} obj
  * @return {String}
  * @example
  *
- *    getResourceCategory(htmlResponse); // => 'content'
+ *    contentType(new Request('foo.html')); // => 'content'
  */
-const getResourceCategory = obj => {
+const contentType = obj => {
   const typeHeader = getResourceTypeHeader(obj);
-  return SMCacheUtils.getMIMECategory(typeHeader);
+  const typePatterns = {
+    image: /^image\//,
+    content: /^text\/(html|xml|xhtml)/
+  };
+  return Object.keys(typePatterns).find(key => {
+    const pattern = typePatterns[key];
+    return pattern.test(typeHeader);
+  });
 };
 
 /**
@@ -159,7 +163,7 @@ addEventListener('fetch', event => {
           return response;
         }
         // The request wasn't found; add it to (and return it from) the cache.
-        return openCache()
+        return openCache(contentType(request))
           .then(cache => cache.add(request))
           .then(() => caches.match(request))
       })

--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -1,7 +1,6 @@
-/* global self, caches, URL, Request, Response */
-/* eslint indent: [2, 2] */
-/* eslint-env es6 */
-
+/**
+ * @ignore
+ */
 'use strict';
 
 const VERSION = '0.0.1';
@@ -26,14 +25,12 @@ const getRequestTypeHeader = curry(getHeader, 'Accept');
 const getResponseTypeHeader = curry(getHeader, 'Content-Type');
 
 /**
- * getResourceTypeHeader receives a Request or Response instance, and it returns
- * a header value indicating the MIME-type of that object.
+ * `getResourceTypeHeader()` receives a `Request` or `Response` instance, and it
+ * returns a header value indicating the MIME-type of that object.
  *
  * @param {Request|Response} obj
  * @return {String}
- * @example
- *
- *    getResourceTypeHeader(cssRequest); // => 'text/css'
+ * @example getResourceTypeHeader(cssRequest); // => 'text/css'
  */
 const getResourceTypeHeader = obj => {
   if (isRequest(obj)) return getRequestTypeHeader(obj);
@@ -41,14 +38,12 @@ const getResourceTypeHeader = obj => {
 };
 
 /**
- * contentType receives a Request or Response instance, and it returns a generic
- * string alias for the MIME-type of that object.
+ * `contentType()` receives a `Request` or `Response` instance, and it returns a
+ * generic string alias for the MIME-type of that object.
  *
  * @param {Request|Response} obj
  * @return {String}
- * @example
- *
- *    contentType(new Request('foo.html')); // => 'content'
+ * @example contentType(new Request('foo.html')); // => 'content'
  */
 const contentType = obj => {
   const typeHeader = getResourceTypeHeader(obj);
@@ -63,19 +58,17 @@ const contentType = obj => {
 };
 
 /**
- * isCacheableURL receives a URL instance and returns true or false depending on
- * whether or not:
+ * `isCacheableURL()` receives a `URL` instance and returns `true` or `false`
+ * depending on whether or not:
  *
- * - its pathname exists within the `cacheablePaths` array
- * - its value matches the `cacheablePattern` regex
+ * - its `pathname` exists within the `cacheablePaths` array
+ * - its value matches the `cacheablePattern` pattern
  *
  * TODO: Clean up that nasty replacement regex (for GH Pages)
  *
- * @param {URL}
+ * @param {URL} url
  * @return {Boolean}
- * @example
- *
- *    isCacheableURL(new URL('example.com/nope')); // => false
+ * @example isCacheableURL(new URL('example.com/nope')); // => false
  */
 const isCacheableURL = url => {
   const path = url.pathname.replace(/(\/)(smashing-mag-sw\/)?/, '');
@@ -85,15 +78,12 @@ const isCacheableURL = url => {
 };
 
 /**
- * isCacheableRequest receives a Request instance and returns true or false
- * depending on the properties of its URL and header values.
+ * `isCacheableRequest()` receives a `Request` instance and returns `true` or
+ * `false` depending on the properties of its URL and header values.
  *
  * @param {Request} request
  * @return {Boolean}
- * @example
- *
- *    isCacheableRequest(siteLogoRequest); // => true
- *    isCacheableRequest(thirdPartyScriptRequest); // => false
+ * @example isCacheableRequest(new Request('logo.svg')); // => true
  */
 const isCacheableRequest = request => {
   const url = new URL(request.url);
@@ -106,15 +96,13 @@ const isCacheableRequest = request => {
 };
 
 /**
- * openCache optionally receives one or more string arguments used to construct
- * a key for caches.open(). If no arguments are supplied, the `VERSION` constant
- * alone will be used as the cache key.
+ * `openCache()` optionally receives one or more string arguments used to
+ * construct a key for `caches.open()`. If no arguments are supplied, the
+ * `VERSION` constant alone will be used as the cache key.
  *
- * @param {...String}
+ * @param {...String} args
  * @return {Promise}
- * @example
- *
- *    openCache('images').then(cache => ...); // key is "0.0.0-images"
+ * @example openCache('images').then(cache => ...); // key is "0.0.0-images"
  */
 const openCache = (...args) => {
   const key = [VERSION].concat(args).join('-');
@@ -122,6 +110,7 @@ const openCache = (...args) => {
 };
 
 /**
+ * @ignore
  * This is the installation handler. It runs when the worker is first installed.
  * It precaches the asset paths in the `cacheablePaths` array.
  */
@@ -134,6 +123,7 @@ self.addEventListener('install', event => {
 });
 
 /**
+ * @ignore
  * This is the activation handler. It runs after the worker is installed. It
  * handles the deletion of stale cache responses.
  */
@@ -150,20 +140,22 @@ self.addEventListener('activate', event => {
 });
 
 /**
+ * @ignore
  * This is the fetch handler. It runs upon every request, but it only acts upon
  * requests that return true when passed to `isCacheableRequest`. It both
  * serves requests from the cache and adds requests to the cache.
+ *
+ * This is tricky:
+ * https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage/match
+ * `.match()` does not seem to throw anything when no matching items are found.
+ * So instead of using `.catch()` here, we use `.then()` and check the value of
+ * response (which could be undefined).
  */
 self.addEventListener('fetch', event => {
   const request = event.request;
   if (isCacheableRequest(request)) {
     event.respondWith(
-      /**
-       * This is tricky:
-       * https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage/match
-       * Opposed to these docs, .match() does not seem to throw anything when no
-       * matching items are found. So instead of using .catch() here, we use
-       * .then() and check the value of response (which could be undefined).
+
        */
       caches.match(request).then(response => {
         // The request was found in the cache; return it.

--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -155,8 +155,6 @@ self.addEventListener('fetch', event => {
   const request = event.request;
   if (isCacheableRequest(request)) {
     event.respondWith(
-
-       */
       caches.match(request).then(response => {
         // The request was found in the cache; return it.
         if (isResponse(response)) {

--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -85,17 +85,17 @@ const isCacheableURL = url => {
 };
 
 /**
- * isRequestCacheable receives a Request instance and returns true or false
+ * isCacheableRequest receives a Request instance and returns true or false
  * depending on the properties of its URL and header values.
  *
  * @param {Request} request
  * @return {Boolean}
  * @example
  *
- *    isRequestCacheable(siteLogoRequest); // => true
- *    isRequestCacheable(thirdPartyScriptRequest); // => false
+ *    isCacheableRequest(siteLogoRequest); // => true
+ *    isCacheableRequest(thirdPartyScriptRequest); // => false
  */
-const isRequestCacheable = request => {
+const isCacheableRequest = request => {
   const url = new URL(request.url);
   const criteria = [
     isCacheableURL(url),
@@ -151,12 +151,12 @@ self.addEventListener('activate', event => {
 
 /**
  * This is the fetch handler. It runs upon every request, but it only acts upon
- * requests that return true when passed to `isRequestCacheable`. It both
+ * requests that return true when passed to `isCacheableRequest`. It both
  * serves requests from the cache and adds requests to the cache.
  */
 self.addEventListener('fetch', event => {
   const request = event.request;
-  if (isRequestCacheable(request)) {
+  if (isCacheableRequest(request)) {
     event.respondWith(
       /**
        * This is tricky:

--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -149,6 +149,11 @@ self.addEventListener('activate', event => {
   );
 });
 
+/**
+ * This is the fetch handler. It runs upon every request, but it only acts upon
+ * requests that return true when passed to `isRequestCacheable`. It both
+ * serves requests from the cache and adds requests to the cache.
+ */
 self.addEventListener('fetch', event => {
   const request = event.request;
   if (isRequestCacheable(request)) {

--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -3,7 +3,7 @@
  */
 'use strict';
 
-const VERSION = '0.0.1';
+const VERSION = '0.0.2';
 const cacheablePattern = /page[1-2]\.html$/;
 const cacheablePaths = [
   'suitcss.css',

--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -26,44 +26,6 @@ const getRequestTypeHeader = curry(getHeader, 'Accept');
 const getResponseTypeHeader = curry(getHeader, 'Content-Type');
 
 /**
- * openCache optionally receives one or more string arguments used to construct
- * a key for caches.open(). If no arguments are supplied, the `VERSION` constant
- * alone will be used as the cache key.
- *
- * @param {...String}
- * @return {Promise}
- * @example
- *
- *    openCache('images').then(cache => ...); // key is "0.0.0-images"
- */
-const openCache = (...args) => {
-  const key = [VERSION].concat(args).join('-');
-  return caches.open(key);
-};
-
-/**
- * isCacheableURL receives a URL instance and returns true or false depending on
- * whether or not:
- *
- * - its pathname exists within the `cacheablePaths` array
- * - its value matches the `cacheablePattern` regex
- *
- * TODO: Clean up that nasty replacement regex (for GH Pages)
- *
- * @param {URL}
- * @return {Boolean}
- * @example
- *
- *    isCacheableURL(new URL('example.com/nope')); // => false
- */
-const isCacheableURL = url => {
-  const path = url.pathname.replace(/(\/)(smashing-mag-sw\/)?/, '');
-  const isPathIncluded = cacheablePaths.includes(path);
-  const isURLMatching = cacheablePattern.test(url);
-  return isPathIncluded || isURLMatching;
-};
-
-/**
  * getResourceTypeHeader receives a Request or Response instance, and it returns
  * a header value indicating the MIME-type of that object.
  *
@@ -101,6 +63,28 @@ const contentType = obj => {
 };
 
 /**
+ * isCacheableURL receives a URL instance and returns true or false depending on
+ * whether or not:
+ *
+ * - its pathname exists within the `cacheablePaths` array
+ * - its value matches the `cacheablePattern` regex
+ *
+ * TODO: Clean up that nasty replacement regex (for GH Pages)
+ *
+ * @param {URL}
+ * @return {Boolean}
+ * @example
+ *
+ *    isCacheableURL(new URL('example.com/nope')); // => false
+ */
+const isCacheableURL = url => {
+  const path = url.pathname.replace(/(\/)(smashing-mag-sw\/)?/, '');
+  const isPathIncluded = cacheablePaths.includes(path);
+  const isURLMatching = cacheablePattern.test(url);
+  return isPathIncluded || isURLMatching;
+};
+
+/**
  * isRequestCacheable receives a Request instance and returns true or false
  * depending on the properties of its URL and header values.
  *
@@ -119,6 +103,22 @@ const isRequestCacheable = request => {
     isGetRequest(request)
   ];
   return criteria.every(result => result);
+};
+
+/**
+ * openCache optionally receives one or more string arguments used to construct
+ * a key for caches.open(). If no arguments are supplied, the `VERSION` constant
+ * alone will be used as the cache key.
+ *
+ * @param {...String}
+ * @return {Promise}
+ * @example
+ *
+ *    openCache('images').then(cache => ...); // key is "0.0.0-images"
+ */
+const openCache = (...args) => {
+  const key = [VERSION].concat(args).join('-');
+  return caches.open(key);
 };
 
 /**


### PR DESCRIPTION
- relocated all of the single-use event handler function directly into the handlers
- removed extraneous abstractions around the caching functions
- introduced the `openCache` function to contain the cache-key-building logic
- added `self` namespace where needed (per eslint errors)
- updated function comments/docs to work better with `doxx` generated output
- removed the `SWCacheUtils.js` import since nothing in it is needed now