### PR TITLE
Feature: WIP Grunt-based solution for keeping precache assets array up to date

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,43 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+
+/**
+ * Read a directory and return an array of its paths
+ */
+function dirListing (p) {
+  return fs.readdirSync(p).map(function (file) {
+    return path.join(p, file);
+  }).filter(function (file) {
+    return fs.statSync(file).isFile();
+  });
+}
+
+module.exports = (function (grunt) {
+  grunt.loadNpmTasks('grunt-regex-replace');
+
+  grunt.initConfig({
+    pkg: grunt.file.readJSON('package.json'),
+    "regex-replace": {
+      /**
+       * Update the contents of serviceWorker-precache.js based on the files
+       * present in the assets directory.
+       */
+      assetPaths: {
+        src: ['serviceWorker-precache.js'],
+        actions: [
+          {
+            search: /const REQUIRED_PATHS = \[([\s\S]+)\]/,
+            replace: function (match, paths) {
+              var newPaths = dirListing('./assets').map(function (path) {
+                return '\n  \'' + path + '\'';
+              });
+              return match.replace(paths, newPaths.join(',') + '\n');
+            }
+          }
+        ]
+      }
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "ava": "^0.12.0",
     "doxdox": "^0.1.10",
+    "grunt": "^0.4.5",
     "http-server": "^0.8.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "ava": "^0.12.0",
     "doxdox": "^0.1.10",
     "grunt": "^0.4.5",
+    "grunt-regex-replace": "^0.2.7",
     "http-server": "^0.8.5"
   }
 }


### PR DESCRIPTION
This is a rough solution for automating the population of https://github.com/cloudfour/smashing-mag-sw/blob/gh-pages/serviceWorker-precache.js using a Grunt task.

I'm not sure this is the right approach, but wanted to start the discussion with an example.

Running `grunt regex-replace` will cause the above file to be updated based on the actual contents of the assets directory. This could be a solution for making sure the SW has an updated record of what it should precache.

Thoughts?

@lyzadanger @mrgerardorodriguez
